### PR TITLE
Fix regex pattern in build.js script

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -74,8 +74,8 @@ async function buildLanguage(language) {
   // Sort files to ensure correct order
   markdownFiles.sort((a, b) => {
     // First by chapter
-    const chapterA = a.match(/chapter-(\\d+)/);
-    const chapterB = b.match(/chapter-(\\d+)/);
+    const chapterA = a.match(/chapter-(\d+)/);
+    const chapterB = b.match(/chapter-(\d+)/);
     
     if (chapterA && chapterB) {
       const chapterNumA = parseInt(chapterA[1]);
@@ -87,8 +87,8 @@ async function buildLanguage(language) {
     }
     
     // Then by section/activity number if within same chapter
-    const sectionA = a.match(/\\/(\\d+)-/);
-    const sectionB = b.match(/\\/(\\d+)-/);
+    const sectionA = a.match(/\/(\d+)-/);
+    const sectionB = b.match(/\/(\d+)-/);
     
     if (sectionA && sectionB) {
       return parseInt(sectionA[1]) - parseInt(sectionB[1]);
@@ -116,7 +116,7 @@ async function buildLanguage(language) {
   // Concatenate all markdown files
   for (const file of markdownFiles) {
     const content = fs.readFileSync(file, 'utf-8');
-    fs.appendFileSync(outputMdFile, content + '\\n\\n');
+    fs.appendFileSync(outputMdFile, content + '\n\n');
   }
   
   console.log(`Created concatenated markdown file: ${outputMdFile}`);
@@ -188,7 +188,7 @@ async function main() {
     // Create placeholder file in case PDF generation fails
     fs.writeFileSync(
       path.join(config.outputDir, 'placeholder.md'),
-      `# ${config.bookName} - Placeholder\\n\\nThis is a placeholder file for when PDF generation fails.`
+      `# ${config.bookName} - Placeholder\n\nThis is a placeholder file for when PDF generation fails.`
     );
     
     // Build each language


### PR DESCRIPTION

## Build Script Fix

This PR fixes the syntax error in the Node.js build script (`tools/build.js`) that was causing the build to fail.

### Changes Made:

The regular expression pattern at line 90 was incorrectly escaped:
- From: `/\\/(\\d+)-/` (incorrect escaping causing syntax error)
- To: `/\/(\d+)-/` (correct JavaScript regex pattern)

This syntax error prevented the build from completing, which also prevented our image handling fixes in PR #28 from being properly tested.

Once this PR is merged, PR #28 can be tested to ensure images properly appear in PDF and EPUB outputs.
