### PR TITLE
Add Docker image configuration for book builder

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,40 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:  # Allow manual triggering
+  push:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-build.yml'
+
+# Set permissions for GitHub Container Registry
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/book-builder:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:24.04
+
+LABEL maintainer="iksnae/actual-intelligence"
+LABEL description="Docker image for building the Actual Intelligence book"
+
+# Prevent apt from prompting for input
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN apt-get update && apt-get install -y \
+    nodejs \
+    npm \
+    pandoc \
+    texlive-xetex \
+    texlive-fonts-recommended \
+    texlive-plain-generic \
+    texlive-lang-english \
+    texlive-latex-extra \
+    calibre \
+    rsync \
+    curl \
+    git \
+    make \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up work directory
+WORKDIR /app
+
+# Create entrypoint script
+RUN echo '#!/bin/bash\nexec "$@"' > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,58 @@
+# Book Builder Docker Image
+
+This Docker image contains all the dependencies needed to build the "Actual Intelligence" book in various formats:
+
+- PDF (via pandoc and LaTeX)
+- EPUB
+- MOBI (via Calibre)
+- HTML
+
+## Included Tools
+
+- Node.js and npm
+- Pandoc
+- XeLaTeX (for PDF generation)
+- Calibre (for MOBI conversion)
+- Git
+- Other build tools (rsync, curl, wget, make)
+
+## Using the Image
+
+### In GitHub Actions
+
+The image is used automatically in our GitHub Actions workflow. See `.github/workflows/build-book.yml`.
+
+### Running Locally
+
+To use this image locally:
+
+```bash
+# Pull the image
+docker pull ghcr.io/iksnae/book-builder:latest
+
+# Run the container with your repository mounted
+docker run -it --rm -v $(pwd):/app ghcr.io/iksnae/book-builder:latest bash
+
+# Inside the container, you can run the build script
+./build.sh
+```
+
+## Building the Image Locally
+
+If you want to build the image locally:
+
+```bash
+# Build
+docker build -t ghcr.io/iksnae/book-builder:latest .
+
+# Run
+docker run -it --rm -v $(pwd):/app ghcr.io/iksnae/book-builder:latest bash
+```
+
+## Troubleshooting
+
+If you encounter issues with the build process:
+
+1. Check if all dependencies are correctly installed in the Dockerfile
+2. Verify that the build script has execution permissions (`chmod +x build.sh`)
+3. Ensure all image paths in your Markdown files are correct


### PR DESCRIPTION
## Fix for Book Build Workflow

This PR fixes the build workflow by adding a Dockerfile and a new GitHub Actions workflow to build and push the Docker image.

### What's included:
1. A Dockerfile that installs all necessary dependencies for building the book:
   - Node.js and npm
   - Pandoc
   - XeLaTeX (for PDF generation)
   - Calibre (for MOBI conversion)
   - Other build tools

2. A GitHub Actions workflow file (`docker-build.yml`) to build and push the Docker image to GitHub Container Registry.

3. Documentation about the Docker image in `docker/README.md`.

### How to use:
1. Merge this PR
2. The Docker build workflow will automatically run, creating the Docker image at `ghcr.io/iksnae/book-builder:latest`
3. Once the image is built, the book build workflow should work correctly

This fixes the "manifest unknown" error that was occurring because the Docker image wasn't found in the registry.