### PR TITLE
Fix Docker image reference in build workflow

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/iksnae/book-builder:latest  # Replace with your image URL
+      image: iksnae/book-builder:latest  # Changed from ghcr.io/iksnae/book-builder:latest to iksnae/book-builder:latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Fix for Book Build Workflow

This PR fixes the book build workflow by updating the Docker image reference.

### Changes Made:
- Changed Docker image reference from `ghcr.io/iksnae/book-builder:latest` to `iksnae/book-builder:latest`

### Background:
The build was failing because it was looking for the Docker image in GitHub Container Registry (ghcr.io) but according to the book-builder repository setup, the image is published to Docker Hub instead. This PR corrects the image reference to point to Docker Hub.

### How to Test:
After merging this PR, the book build workflow should work correctly since the Docker image exists at `iksnae/book-builder:latest` on Docker Hub.

The Docker image contains all necessary dependencies for building the book:
- Node.js and npm
- Pandoc for document conversion
- XeLaTeX for PDF generation
- Calibre for MOBI conversion
- Other tools needed for the build process