### PR TITLE
Fix GitHub Pages deployment by separating workflow jobs

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -20,9 +20,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     container:
-      image: iksnae/book-builder:latest  # Replace with your image URL
+      image: iksnae/book-builder:latest
 
     steps:
       - uses: actions/checkout@v4
@@ -77,6 +76,25 @@ jobs:
             build/*.html
             build/*.md
             build/es/*
+            build/images/*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: book-files
+          path: build
+
+      - name: Get current date
+        id: date
+        run: echo "DATE=$(date +'%B %d, %Y')" >> $GITHUB_ENV
+
+      - name: Set version
+        id: version
+        run: echo "VERSION=$(date +'v%Y.%m.%d-%H%M')" >> $GITHUB_ENV
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
## Fix for GitHub Pages Deployment

This PR separates the workflow into two distinct jobs:

1. **Build Job**: Uses the Docker container to build the book files
   - Runs entirely within the `iksnae/book-builder` Docker container
   - Focuses solely on building book files (PDF, EPUB, MOBI, HTML)
   - Uploads artifacts for the next job

2. **Release & Deploy Job**: Runs on the GitHub runner directly
   - Downloads artifacts from the build job
   - Creates GitHub release with the book files
   - Handles GitHub Pages deployment without needing rsync in the Docker container

### Why This Approach:

This approach follows the principle of separation of concerns:
- The Docker image (`book-builder`) only needs to handle book building
- The GitHub runner handles deployment tasks, which is its specialty
- We don't need to add rsync to the Docker image, keeping it focused and minimal

### How to Test:
- After merging, the workflow will run properly without the "rsync not found" error
- GitHub Pages will deploy successfully

This approach keeps your Docker container focused on its primary task (building books) and leverages GitHub's runners for deployment operations.