### PR TITLE
Fix GitHub Pages deployment by adding checkout step

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -82,6 +82,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      # Add checkout step so Git commands work properly
+      - uses: actions/checkout@v4
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Fix for GitHub Pages Deployment Error

This PR addresses the git error occurring during GitHub Pages deployment:

```
fatal: not in a git directory
There was an error initializing the repository: The process '/usr/bin/git' failed with exit code 128
```

### Changes Made:

- Added a checkout step to the release job:
  ```yaml
  # Add checkout step so Git commands work properly
  - uses: actions/checkout@v4
  ```

### Why This Change is Needed:

The GitHub Pages deployment action (`JamesIves/github-pages-deploy-action`) requires access to the git repository to function properly. Without the checkout step in the release job, the action is trying to run git commands in a directory that isn't a git repository.

### How to Test:

After merging this PR, the GitHub Pages deployment should work correctly without the git error.

This is a small but critical fix that ensures the multi-job workflow works as expected.