### PR TITLE
Enable multi-language build and build on all branches

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -2,7 +2,7 @@ name: Build Book
 
 on:
   push:
-    branches: [main]
+    # Run on any branch
     paths:
       - 'book/**'
       - 'art/**'
@@ -63,7 +63,8 @@ jobs:
         run: |
           echo "Running enhanced build script..."
           chmod +x build.sh
-          ./build.sh || echo "Build script completed with warnings"
+          # Run the build script with the all-languages flag
+          ./build.sh --all-languages || echo "Build script completed with warnings"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -79,6 +80,8 @@ jobs:
             build/images/*
 
   release:
+    # Only run release job on main branch
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +93,9 @@ jobs:
         with:
           name: book-files
           path: build
+
+      - name: List build directory contents
+        run: ls -la build/
 
       - name: Get current date
         id: date

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,24 @@
 # Set to continue even when commands fail (we'll handle errors)
 set +e
 
+# Parse command line arguments
+BUILD_ALL_LANGUAGES=false
+SPECIFIC_LANGUAGE=""
+
+for arg in "$@"
+do
+  case $arg in
+    --all-languages)
+      BUILD_ALL_LANGUAGES=true
+      shift
+      ;;
+    --lang=*)
+      SPECIFIC_LANGUAGE="${arg#*=}"
+      shift
+      ;;
+  esac
+do
+
 # Create build directory if it doesn't exist
 mkdir -p build
 
@@ -18,10 +36,12 @@ if [ -f "art/cover.png" ]; then
   # Ensure book/images directories exist
   mkdir -p book/images
   mkdir -p book/en/images
+  mkdir -p book/es/images
   
   # Copy cover to book directories for consistency
   cp "$COVER_IMAGE" book/images/cover.png
   cp "$COVER_IMAGE" book/en/images/cover.png
+  cp "$COVER_IMAGE" book/es/images/cover.png
 elif [ -f "book/images/cover.png" ]; then
   echo "✅ Found cover image at book/images/cover.png"
   COVER_IMAGE="book/images/cover.png"
@@ -55,12 +75,13 @@ npm install
 # Create directories for images in the build folder
 echo "Creating image directories in build folder..."
 mkdir -p build/images
+mkdir -p build/es/images
 
 # Copy all image directories to the build folder to ensure proper path resolution
 echo "Copying image directories..."
 find book -path "*/images" -type d | while read -r imgdir; do
   echo "Found image directory: $imgdir"
-  # Use rsync to copy only existing files and ignore errors
+  # Use cp to copy directories and ignore errors
   mkdir -p "build/$(dirname "$imgdir")"
   cp -r "$imgdir" "build/$(dirname "$imgdir")/" 2>/dev/null || true
   echo "Copied $imgdir to build/"
@@ -72,15 +93,40 @@ if [ -d "book/en/images" ]; then
   cp -r book/en/images/* build/images/ 2>/dev/null || true
 fi
 
+if [ -d "book/es/images" ]; then
+  echo "Copying book/es/images to build/es/images..."
+  cp -r book/es/images/* build/es/images/ 2>/dev/null || true
+  # Also copy to root images for cross-referencing
+  cp -r book/es/images/* build/images/ 2>/dev/null || true
+fi
+
 if [ -d "book/images" ]; then
   echo "Copying book/images to build/images..."
   cp -r book/images/* build/images/ 2>/dev/null || true
+  # Also copy to es images for cross-referencing
+  cp -r book/images/* build/es/images/ 2>/dev/null || true
 fi
 
 # Step 2: Build book using custom Node.js script if it exists
 if [ -f "tools/build.js" ]; then
   echo "Running custom build script..."
-  npm run build || true  # Continue even if errors occur
+  
+  # Pass appropriate flags to the Node.js build script
+  if [ "$BUILD_ALL_LANGUAGES" = true ]; then
+    echo "Building all languages..."
+    npm run build -- --all-languages || true  # Continue even if errors occur
+  elif [ -n "$SPECIFIC_LANGUAGE" ]; then
+    echo "Building specific language: $SPECIFIC_LANGUAGE"
+    npm run build -- --lang="$SPECIFIC_LANGUAGE" || true  # Continue even if errors occur
+  else
+    # By default, build all languages in CI
+    if [ -n "$CI" ]; then
+      echo "Running in CI environment, building all languages by default"
+      npm run build -- --all-languages || true  # Continue even if errors occur
+    else
+      npm run build || true  # Continue even if errors occur
+    fi
+  fi
 else
   echo "No custom build script found. Using direct Pandoc compilation."
   # Create a combined markdown file for the book
@@ -125,159 +171,161 @@ else
 fi
 
 # Define common resource paths to help pandoc find images
-RESOURCE_PATHS=".:book:book/en:build:book/en/images:book/images:build/images"
+RESOURCE_PATHS=".:book:book/en:book/es:build:book/en/images:book/es/images:book/images:build/images:build/es/images"
 
 # Create a modified version of the Markdown file that makes image references optional
 echo "Creating fallback markdown version for resilient PDF generation..."
-cp build/actual-intelligence.md build/actual-intelligence-safe.md
+if [ -f "build/actual-intelligence.md" ]; then
+  cp build/actual-intelligence.md build/actual-intelligence-safe.md
 
-# Step 3: Generate PDF with our template (with error handling)
-echo "Generating PDF..."
-if [ -n "$TEMP_TEMPLATE" ]; then
-  # First attempt: Use our custom template with resource path for images
-  pandoc build/actual-intelligence.md -o build/actual-intelligence.pdf \
-    --template="$TEMP_TEMPLATE" \
-    --metadata title="Actual Intelligence" \
-    --pdf-engine=xelatex \
-    --toc \
-    --resource-path="$RESOURCE_PATHS"
-else
-  # First attempt: Fallback to default pandoc styling with resource path for images
-  pandoc build/actual-intelligence.md -o build/actual-intelligence.pdf \
-    --metadata title="Actual Intelligence" \
-    --pdf-engine=xelatex \
-    --toc \
-    --resource-path="$RESOURCE_PATHS"
-fi
+  # Step 3: Generate PDF with our template (with error handling)
+  echo "Generating PDF..."
+  if [ -n "$TEMP_TEMPLATE" ]; then
+    # First attempt: Use our custom template with resource path for images
+    pandoc build/actual-intelligence.md -o build/actual-intelligence.pdf \
+      --template="$TEMP_TEMPLATE" \
+      --metadata title="Actual Intelligence" \
+      --pdf-engine=xelatex \
+      --toc \
+      --resource-path="$RESOURCE_PATHS"
+  else
+    # First attempt: Fallback to default pandoc styling with resource path for images
+    pandoc build/actual-intelligence.md -o build/actual-intelligence.pdf \
+      --metadata title="Actual Intelligence" \
+      --pdf-engine=xelatex \
+      --toc \
+      --resource-path="$RESOURCE_PATHS"
+  fi
 
-# Check if PDF file exists and has content
-if [ $? -ne 0 ] || [ ! -s "build/actual-intelligence.pdf" ]; then
-  echo "First PDF generation attempt failed, trying with more resilient settings..."
-  
-  # Create a version of the markdown with image references made more resilient
-  sed -i 's/!\[\([^]]*\)\](\([^)]*\))/!\[\1\](images\/\2)/g' build/actual-intelligence-safe.md
-  
-  # Second attempt: Try with modified settings and more lenient image paths
-  pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.pdf \
-    --metadata title="Actual Intelligence" \
-    --pdf-engine=xelatex \
-    --toc \
-    --variable=graphics=true \
-    --variable=documentclass=book \
-    --resource-path="$RESOURCE_PATHS" || true
-  
-  # If still not successful, create a minimal PDF
-  if [ ! -s "build/actual-intelligence.pdf" ]; then
-    echo "WARNING: PDF generation with images failed, creating a minimal PDF without images..."
-    # Create a version with image references removed
-    sed -i 's/!\[\([^]]*\)\](\([^)]*\))//g' build/actual-intelligence-safe.md
+  # Check if PDF file exists and has content
+  if [ $? -ne 0 ] || [ ! -s "build/actual-intelligence.pdf" ]; then
+    echo "First PDF generation attempt failed, trying with more resilient settings..."
     
-    # Final attempt: minimal PDF with no images
+    # Create a version of the markdown with image references made more resilient
+    sed -i 's/!\[\([^]]*\)\](\([^)]*\))/!\[\1\](images\/\2)/g' build/actual-intelligence-safe.md
+    
+    # Second attempt: Try with modified settings and more lenient image paths
     pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.pdf \
       --metadata title="Actual Intelligence" \
       --pdf-engine=xelatex \
       --toc \
+      --variable=graphics=true \
+      --variable=documentclass=book \
       --resource-path="$RESOURCE_PATHS" || true
-      
-    # If all else fails, create a placeholder PDF
+    
+    # If still not successful, create a minimal PDF
     if [ ! -s "build/actual-intelligence.pdf" ]; then
-      echo "WARNING: All PDF generation attempts failed, creating placeholder PDF..."
-      echo "# Actual Intelligence - Placeholder PDF" > build/placeholder.md
-      echo "PDF generation encountered issues with images. Please see HTML or EPUB versions." >> build/placeholder.md
-      pandoc build/placeholder.md -o build/actual-intelligence.pdf --pdf-engine=xelatex
+      echo "WARNING: PDF generation with images failed, creating a minimal PDF without images..."
+      # Create a version with image references removed
+      sed -i 's/!\[\([^]]*\)\](\([^)]*\))//g' build/actual-intelligence-safe.md
+      
+      # Final attempt: minimal PDF with no images
+      pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.pdf \
+        --metadata title="Actual Intelligence" \
+        --pdf-engine=xelatex \
+        --toc \
+        --resource-path="$RESOURCE_PATHS" || true
+        
+      # If all else fails, create a placeholder PDF
+      if [ ! -s "build/actual-intelligence.pdf" ]; then
+        echo "WARNING: All PDF generation attempts failed, creating placeholder PDF..."
+        echo "# Actual Intelligence - Placeholder PDF" > build/placeholder.md
+        echo "PDF generation encountered issues with images. Please see HTML or EPUB versions." >> build/placeholder.md
+        pandoc build/placeholder.md -o build/actual-intelligence.pdf --pdf-engine=xelatex
+      fi
     fi
   fi
-fi
 
-# Step 4: Generate EPUB with cover image and extract media
-echo "Generating EPUB file..."
-if [ -n "$COVER_IMAGE" ]; then
-  echo "Including cover image in EPUB: $COVER_IMAGE"
-  pandoc build/actual-intelligence.md -o build/actual-intelligence.epub \
-    --epub-cover-image="$COVER_IMAGE" \
-    --toc \
-    --toc-depth=2 \
-    --metadata title="Actual Intelligence" \
-    --metadata publisher="Khaos Studios" \
-    --metadata creator="Open Source Community" \
-    --resource-path="$RESOURCE_PATHS" \
-    --extract-media=build/epub-media || true
-else
-  pandoc build/actual-intelligence.md -o build/actual-intelligence.epub \
-    --toc \
-    --toc-depth=2 \
-    --metadata title="Actual Intelligence" \
-    --metadata publisher="Khaos Studios" \
-    --metadata creator="Open Source Community" \
-    --resource-path="$RESOURCE_PATHS" \
-    --extract-media=build/epub-media || true
-fi
-
-# Create EPUB if it doesn't exist
-if [ ! -s "build/actual-intelligence.epub" ]; then
-  echo "WARNING: EPUB generation failed, creating minimal EPUB without images..."
-  # Create a version with image references removed
-  sed -i 's/!\[\([^]]*\)\](\([^)]*\))//g' build/actual-intelligence-safe.md
-  
-  pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.epub \
-    --toc \
-    --toc-depth=2 \
-    --metadata title="Actual Intelligence" \
-    --metadata publisher="Khaos Studios" \
-    --metadata creator="Open Source Community" \
-    --resource-path="$RESOURCE_PATHS" || true
-fi
-
-echo "EPUB file generated: build/actual-intelligence.epub"
-
-# Step 4.5: Generate MOBI file from EPUB using Calibre
-echo "Generating MOBI file..."
-if [ -s "build/actual-intelligence.epub" ]; then
-  # Use Calibre's ebook-convert to convert EPUB to MOBI
-  ebook-convert build/actual-intelligence.epub build/actual-intelligence.mobi \
-    --title="Actual Intelligence" \
-    --authors="Open Source Community" \
-    --publisher="Khaos Studios" \
-    --language="en" || true
-    
-  if [ -s "build/actual-intelligence.mobi" ]; then
-    echo "MOBI file generated: build/actual-intelligence.mobi"
+  # Step 4: Generate EPUB with cover image and extract media
+  echo "Generating EPUB file..."
+  if [ -n "$COVER_IMAGE" ]; then
+    echo "Including cover image in EPUB: $COVER_IMAGE"
+    pandoc build/actual-intelligence.md -o build/actual-intelligence.epub \
+      --epub-cover-image="$COVER_IMAGE" \
+      --toc \
+      --toc-depth=2 \
+      --metadata title="Actual Intelligence" \
+      --metadata publisher="Khaos Studios" \
+      --metadata creator="Open Source Community" \
+      --resource-path="$RESOURCE_PATHS" \
+      --extract-media=build/epub-media || true
   else
-    echo "WARNING: MOBI generation failed."
+    pandoc build/actual-intelligence.md -o build/actual-intelligence.epub \
+      --toc \
+      --toc-depth=2 \
+      --metadata title="Actual Intelligence" \
+      --metadata publisher="Khaos Studios" \
+      --metadata creator="Open Source Community" \
+      --resource-path="$RESOURCE_PATHS" \
+      --extract-media=build/epub-media || true
   fi
-else
-  echo "WARNING: Cannot generate MOBI file because EPUB generation failed."
-fi
 
-# Step 5: Generate HTML file from Markdown files with images
-echo "Generating HTML file..."
-pandoc build/actual-intelligence.md -o build/actual-intelligence.html \
-  --standalone \
-  --toc \
-  --toc-depth=2 \
-  --resource-path="$RESOURCE_PATHS" \
-  --metadata title="Actual Intelligence" || true
+  # Create EPUB if it doesn't exist
+  if [ ! -s "build/actual-intelligence.epub" ]; then
+    echo "WARNING: EPUB generation failed, creating minimal EPUB without images..."
+    # Create a version with image references removed
+    sed -i 's/!\[\([^]]*\)\](\([^)]*\))//g' build/actual-intelligence-safe.md
+    
+    pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.epub \
+      --toc \
+      --toc-depth=2 \
+      --metadata title="Actual Intelligence" \
+      --metadata publisher="Khaos Studios" \
+      --metadata creator="Open Source Community" \
+      --resource-path="$RESOURCE_PATHS" || true
+  fi
 
-# Check if HTML file exists
-if [ ! -s "build/actual-intelligence.html" ]; then
-  echo "WARNING: HTML file generation failed with images, trying without..."
-  pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.html \
+  echo "EPUB file generated: build/actual-intelligence.epub"
+
+  # Step 4.5: Generate MOBI file from EPUB using Calibre
+  echo "Generating MOBI file..."
+  if [ -s "build/actual-intelligence.epub" ]; then
+    # Use Calibre's ebook-convert to convert EPUB to MOBI
+    ebook-convert build/actual-intelligence.epub build/actual-intelligence.mobi \
+      --title="Actual Intelligence" \
+      --authors="Open Source Community" \
+      --publisher="Khaos Studios" \
+      --language="en" || true
+      
+    if [ -s "build/actual-intelligence.mobi" ]; then
+      echo "MOBI file generated: build/actual-intelligence.mobi"
+    else
+      echo "WARNING: MOBI generation failed."
+    fi
+  else
+    echo "WARNING: Cannot generate MOBI file because EPUB generation failed."
+  fi
+
+  # Step 5: Generate HTML file from Markdown files with images
+  echo "Generating HTML file..."
+  pandoc build/actual-intelligence.md -o build/actual-intelligence.html \
     --standalone \
     --toc \
     --toc-depth=2 \
     --resource-path="$RESOURCE_PATHS" \
     --metadata title="Actual Intelligence" || true
-    
+
+  # Check if HTML file exists
   if [ ! -s "build/actual-intelligence.html" ]; then
-    echo "ERROR: All HTML generation attempts failed, creating minimal HTML..."
-    echo "<html><head><title>Actual Intelligence</title></head><body><h1>Actual Intelligence</h1><p>HTML generation encountered issues. Please see PDF or EPUB versions.</p></body></html>" > build/actual-intelligence.html
+    echo "WARNING: HTML file generation failed with images, trying without..."
+    pandoc build/actual-intelligence-safe.md -o build/actual-intelligence.html \
+      --standalone \
+      --toc \
+      --toc-depth=2 \
+      --resource-path="$RESOURCE_PATHS" \
+      --metadata title="Actual Intelligence" || true
+      
+    if [ ! -s "build/actual-intelligence.html" ]; then
+      echo "ERROR: All HTML generation attempts failed, creating minimal HTML..."
+      echo "<html><head><title>Actual Intelligence</title></head><body><h1>Actual Intelligence</h1><p>HTML generation encountered issues. Please see PDF or EPUB versions.</p></body></html>" > build/actual-intelligence.html
+    fi
   fi
+
+  echo "HTML file generated: build/actual-intelligence.html"
+
+  # Create index.html from the HTML file for GitHub Pages
+  cp build/actual-intelligence.html build/index.html
 fi
-
-echo "HTML file generated: build/actual-intelligence.html"
-
-# Create index.html from the HTML file for GitHub Pages
-cp build/actual-intelligence.html build/index.html
 
 # List the build folder contents for verification
 echo "Contents of build/ directory:"


### PR DESCRIPTION
## Enable Multi-language Build and Build on All Branches

This PR fixes two important issues:

1. **Spanish resources not appearing in the build assets**:
   - Updated build.sh to properly process command line arguments (--all-languages, --lang=xx)
   - Modified workflow to call build script with the --all-languages flag
   - Added Spanish-specific image directories and resource paths
   - Added copy operations to ensure Spanish assets are correctly built and copied to the right locations

2. **Building on all branches**:
   - Removed branch restriction for the build job (now builds on any branch)
   - Only the release job is restricted to the main branch for publishing
   - Added debug output to list build directory contents before release

### Key Changes:

- **Build.sh Improvements**:
  - Added command-line argument parsing
  - Added specific handling for Spanish images
  - Improved image handling for cross-language referencing
  - Added detection for CI environment to always build all languages in CI
  
- **Workflow Changes**:
  - Removed branch restriction for build job
  - Added conditional for release job to only run on main branch
  - Added directory listing step to debug build contents
  - Force building of all languages by passing --all-languages flag

This PR ensures that both English and Spanish books will be built and published in the release assets, and that builds will run on all branches (with releases only on main).